### PR TITLE
Fixed bug with importing files

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,9 +29,7 @@ Twig.extend(function(Twig) {
                         break;
                     case 'Twig.logic.type.import':
                         if (token.token.expression != '_self') {
-                            _.each(token.token.stack, function(token) {
-                                includes.push("twig!" + token.value + ".twig");
-                            });
+                            _.each(token.token.stack, processDependency);
                         }
                         break;
                     case 'Twig.logic.type.include':


### PR DESCRIPTION
When parsing import tags, the paths were not resolved and injected back into the twig template, so the twig ID matching wasn't working.