### PR TITLE
Feature/rebuild in watch mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var _ = require("underscore");
 var path = require("path");
 var loaderUtils = require("loader-utils");
 
+Twig.cache(false);
+
 Twig.extend(function(Twig) {
     var compiler = Twig.compiler;
 
@@ -53,7 +55,7 @@ Twig.extend(function(Twig) {
 
         if (includes.length > 0) {
             _.each(_.uniq(includes), function(file) {
-                output.unshift("require("+ JSON.stringify("twig!" + file) +");\n");
+                output.unshift("require("+ JSON.stringify(file) +");\n");
             });
         }
 
@@ -65,16 +67,12 @@ module.exports = function(source) {
     var id = require.resolve(this.resource),
         tpl;
     this.cacheable && this.cacheable();
-
-    // check if template already exists
-    tpl = Twig.twig({ ref: id });
-    if (!tpl) {
-        tpl = Twig.twig({
-            id: id,
-            data: source,
-            allowInlineIncludes: true
-        });
-    }
+    
+    tpl = Twig.twig({
+        id: id,
+        data: source,
+        allowInlineIncludes: true
+    });
 
     tpl = tpl.compile({
         module: 'webpack',

--- a/test/embed.test.js
+++ b/test/embed.test.js
@@ -1,0 +1,39 @@
+var should = require("should");
+
+var fs = require("fs");
+var path = require("path");
+
+var runLoader = require("./fakeModuleSystem");
+var twigLoader = require("../");
+
+var fixtures = path.join(__dirname, "fixtures");
+
+describe("embed", function() {
+  it("should generate proper require embed tag", function(done) {
+    var template = path.join(fixtures, "embed", "template.html.twig");
+    runLoader(twigLoader, path.join(fixtures, "extend"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
+      if(err) throw err;
+
+      result.should.have.type("string");
+
+      // verify the generated module imports the `embed`d templates
+      result.should.match(/require\(\"embed\.html\.twig\"\);/);
+
+      done();
+    });
+  });
+
+  it("should generate proper require include tag in block tag", function(done) {
+    var template = path.join(fixtures, "embed", "template.html.twig");
+    runLoader(twigLoader, path.join(fixtures, "extend"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
+      if(err) throw err;
+
+      result.should.have.type("string");
+
+      // verify the generated module imports the `include`d templates
+      result.should.match(/require\(\"include\.html\.twig\"\);/);
+
+      done();
+    });
+  });
+});

--- a/test/extends.test.js
+++ b/test/extends.test.js
@@ -17,7 +17,7 @@ describe("extend", function() {
       result.should.have.type("string");
 
       // verify the generated module imports the `include`d templates
-      result.should.match(/require\(\"twig\!a\.html\.twig\"\);/);
+      result.should.match(/require\(\"a\.html\.twig\"\);/);
 
       done();
     });

--- a/test/fixtures/embed/template.html.twig
+++ b/test/fixtures/embed/template.html.twig
@@ -1,0 +1,5 @@
+{% embed 'embed.html.twig' %}
+    {% block body %}
+        {% include 'include.html.twig' %}
+    {% endblock %}
+{% endembed %}

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -17,13 +17,13 @@ describe("include", function() {
       result.should.have.type("string");
 
       // verify the generated module imports the `include`d templates
-      result.should.match(/require\(\"twig\!\.\/a\.html\.twig\"\);/);
-      result.should.match(/require\(\"twig\!\.\/b\.html\.twig\"\);/);
-      result.should.match(/require\(\"twig\!\.\/c\.html\.twig\"\);/);
-      result.should.match(/require\(\"twig\!\.\/d\.html\.twig\"\);/);
-      result.should.match(/require\(\"twig\!\.\/e\.html\.twig\"\);/);
-      result.should.match(/require\(\"twig\!\.\/f\.html\.twig\"\);/);
-      result.should.match(/require\(\"twig\!\.\/g\.html\.twig\"\);/);
+      result.should.match(/require\(\"\.\/a\.html\.twig\"\);/);
+      result.should.match(/require\(\"\.\/b\.html\.twig\"\);/);
+      result.should.match(/require\(\"\.\/c\.html\.twig\"\);/);
+      result.should.match(/require\(\"\.\/d\.html\.twig\"\);/);
+      result.should.match(/require\(\"\.\/e\.html\.twig\"\);/);
+      result.should.match(/require\(\"\.\/f\.html\.twig\"\);/);
+      result.should.match(/require\(\"\.\/g\.html\.twig\"\);/);
 
       done();
     });


### PR DESCRIPTION
Fix Disable caching #6
**Problem**: webpack in watch mode not recompile twig file and  not update bundle.
**Solution**:

- disable cache in twig, for update template.
```javascript
Twig.cache(false);
```
- remove twig loader from generated js file by twig. It re-triggering an already parsed file.
```
output.unshift("require("+ JSON.stringify(file) +");\n");
```
- and remove check cached template in twig.
- fix test for this pull request.
- add test for embed tag :)
