### PR TITLE
Feature: namespace support

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -4,59 +4,89 @@ var _ = require("underscore");
 var loaderUtils = require("loader-utils");
 var mapcache = require("./mapcache");
 
-module.exports = function(id, tokens, pathToTwig) {
+module.exports = function(loaderOptions) {
+  return function(id, tokens, pathToTwig) {
     var includes = [];
-    var resourcePath = mapcache.get(id);
     var processDependency = function(token) {
-        includes.push(token.value);
-        token.value = hashGenerator(path.resolve(path.dirname(resourcePath), token.value));
+      var fileName = token.value;
+      if (fileName.match(/@/) && loaderOptions && loaderOptions.namespaces) {
+        Object.keys(loaderOptions.namespaces).forEach((key) => {
+          fileName = fileName.replace(new RegExp(`@${key}`), loaderOptions.namespaces[key]);
+        })
+        fileName = path.resolve(process.cwd(), fileName)
+      }
+      token.value = fileName;
+      includes.push(token.value);
+      token.value = hashGenerator(fileName);
     };
 
     var processToken = function(token) {
-        if (token.type == "logic" && token.token.type) {
-            switch(token.token.type) {
-                case 'Twig.logic.type.block':
-                case 'Twig.logic.type.if':
-                case 'Twig.logic.type.elseif':
-                case 'Twig.logic.type.else':
-                case 'Twig.logic.type.for':
-                case 'Twig.logic.type.spaceless':
-                case 'Twig.logic.type.macro':
-                    _.each(token.token.output, processToken);
-                    break;
-                case 'Twig.logic.type.extends':
-                case 'Twig.logic.type.include':
-                    _.each(token.token.stack, processDependency);
-                    break;
-                case 'Twig.logic.type.embed':
-                    _.each(token.token.output, processToken);
-                    _.each(token.token.stack, processDependency);
-                    break;
-                case 'Twig.logic.type.import':
-                case 'Twig.logic.type.from':
-                    if (token.token.expression != '_self') {
-                        _.each(token.token.stack, processDependency);
-                    }
-                    break;
+      if (token.type == "logic" && token.token.type) {
+        switch (token.token.type) {
+          case 'Twig.logic.type.block':
+          case 'Twig.logic.type.if':
+          case 'Twig.logic.type.elseif':
+          case 'Twig.logic.type.else':
+          case 'Twig.logic.type.for':
+          case 'Twig.logic.type.spaceless':
+          case 'Twig.logic.type.macro':
+            _.each(
+              token.token.output,
+              processToken
+            );
+            break;
+          case 'Twig.logic.type.extends':
+          case 'Twig.logic.type.include':
+            _.each(
+              token.token.stack,
+              processDependency
+            );
+            break;
+          case 'Twig.logic.type.embed':
+            _.each(
+              token.token.output,
+              processToken
+            );
+            _.each(
+              token.token.stack,
+              processDependency
+            );
+            break;
+          case 'Twig.logic.type.import':
+          case 'Twig.logic.type.from':
+            if (token.token.expression != '_self') {
+              _.each(
+                token.token.stack,
+                processDependency
+              );
             }
+            break;
         }
+      }
     };
 
     var parsedTokens = JSON.parse(tokens);
 
-    _.each(parsedTokens, processToken);
+    _.each(
+      parsedTokens,
+      processToken
+    );
 
     var output = [
-        'var twig = require("' + pathToTwig + '").twig,',
-        '    template = twig({id:' + JSON.stringify(id) + ', data:' + JSON.stringify(parsedTokens) + ', allowInlineIncludes: true, rethrow: true});\n',
-        'module.exports = function(context) { return template.render(context); }'
+      'var twig = require("' + pathToTwig + '").twig,',
+      '    template = twig({id:' + JSON.stringify(id) + ', data:' + JSON.stringify(parsedTokens) + ', allowInlineIncludes: true, rethrow: true});\n',
+      'module.exports = function(context) { return template.render(context); }'
     ];
 
     if (includes.length > 0) {
-        _.each(_.uniq(includes), function(file) {
-            output.unshift("require("+ JSON.stringify(file) +");\n");
-        });
+      _.each(
+        _.uniq(includes),
+        function(file) {
+          output.unshift("require(" + JSON.stringify(file) + ");\n");
+        }
+      );
     }
 
     return output.join('\n');
+  }
 };

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -2,16 +2,20 @@ var Twig = require("twig");
 var path = require("path");
 var hashGenerator = require("hasha");
 var mapcache = require("./mapcache");
+var compiler = require("./compiler")
+var loaderUtils = require("loader-utils")
 
 Twig.cache(false);
 
-Twig.extend(function(Twig) {
-    var compiler = Twig.compiler;
-    compiler.module['webpack'] = require("./compiler");
-});
-
 module.exports = function(source) {
-    var path = require.resolve(this.resource),
+  const loaderOptions = loaderUtils.getOptions(this) || {};
+  Twig.extend(function(Twig) {
+    // we want to have the loader context within the compiler, therefore we have
+    // to bind the context to the compiler function
+    Twig.compiler.module['webpack'] = compiler(loaderOptions);
+  });
+
+  var path = require.resolve(this.resource),
         id = hashGenerator(path),
         tpl;
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "hasha": "^2.2.0",
-    "loader-utils": "^0.2.11",
+    "loader-utils": "^1.1.0",
     "map-cache": "^0.2.2",
     "twig": "~0.8.9",
     "underscore": "^1.8.3"

--- a/test/embed.test.js
+++ b/test/embed.test.js
@@ -11,7 +11,7 @@ var fixtures = path.join(__dirname, "fixtures");
 describe("embed", function() {
   it("should generate proper require embed tag", function(done) {
     var template = path.join(fixtures, "embed", "template.html.twig");
-    runLoader(twigLoader, path.join(fixtures, "extend"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
+    runLoader(twigLoader, path.join(fixtures, "embed"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
       if(err) throw err;
 
       result.should.have.type("string");
@@ -25,7 +25,7 @@ describe("embed", function() {
 
   it("should generate proper require include tag in block tag", function(done) {
     var template = path.join(fixtures, "embed", "template.html.twig");
-    runLoader(twigLoader, path.join(fixtures, "extend"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
+    runLoader(twigLoader, path.join(fixtures, "embed"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
       if(err) throw err;
 
       result.should.have.type("string");
@@ -36,4 +36,27 @@ describe("embed", function() {
       done();
     });
   });
+
+  it("should work with namespaces", function(done) {
+    var template = path.join(fixtures, "embed", "namespaces.html.twig");
+    let loaderOptions = {
+      namespaces: {
+        namespace1: "/path/to/namespace1"
+      }
+    };
+    runLoader(twigLoader, path.join(fixtures, "extend"), template, fs.readFileSync(template, "utf-8"), function(err, result) {
+      if(err) throw err;
+
+      result.should.have.type("string");
+
+      const pathToEmbed = path.resolve(process.cwd(), loaderOptions.namespaces.namespace1);
+
+      const regExp = new RegExp(`require\\("${pathToEmbed}/embed.html.twig"\\);`)
+      // verify the generated module imports the `embed`d templates
+      result.should.match(regExp);
+
+      done();
+    }, loaderOptions);
+  });
+
 });

--- a/test/fakeModuleSystem.js
+++ b/test/fakeModuleSystem.js
@@ -1,7 +1,7 @@
 var fs = require("fs");
 var path = require("path");
 
-module.exports = function runLoader(loader, directory, filename, arg, callback) {
+module.exports = function runLoader(loader, directory, filename, arg, callback, options) {
   var async = true;
   var loaderContext = {
     async: function() {
@@ -10,7 +10,7 @@ module.exports = function runLoader(loader, directory, filename, arg, callback) 
     },
     loaders: ["itself"],
     loaderIndex: 0,
-    query: "",
+    query: options || "",
     resource: filename,
     callback: function() {
       async = true;


### PR DESCRIPTION
I'm working on a project where we are using namespaces within twig. Therefore I've implemented the functionality into the loader.

Work done:
- [x] webpacks loader options are past through to the compiler
- [x] extended fakeModuleSystem.js to allow options in tests
- [x] implemented namespace replacements for all includes files
- [x] added test for namespace within embed

Stuff I would do I've you would like to merge the PR:
- reorder fakeModuleSystem parameters, so that the callback is the last parameter again
- write tests for include & extend