### PR TITLE
Add additional option

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -28,10 +28,14 @@ module.exports = function(source) {
         allowInlineIncludes: true
     });
 
-    tpl = tpl.compile({
-        module: 'webpack',
-        twig: 'twig'
-    });
+    if (options.mode === 'render') {
+        tpl = tpl.render();
+    } else {
+        tpl = tpl.compile({
+            module: 'webpack',
+            twig: 'twig'
+        });
+    }
 
     this.callback(null, tpl);
 };


### PR DESCRIPTION
Hi,

With this option we can get html object and then use it with html-loader plugin or others. It is really useful when we want create html files with webpack and HtmlWebpackPlugin

`new HtmlWebpackPlugin({
            filename: 'index.html',
            template: '!!html-loader!twig-loader?mode=render!pages/index.twig',
            inject: 'body'
}),`

For internal use or ajax requests we can keep just one loader

`{
                test: /\.twig$/,
                use: [
                    {
                        loader: "twig-loader",
                        options: {},
                    },
                ]
}`

Thank you.