### PR TITLE
Add support for webpack >= 4.0.0

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -7,6 +7,7 @@ module.exports = function (options) {
     return function (id, tokens, pathToTwig) {
 
         var loaderApi = options.loaderApi;
+        var context = loaderApi.rootContext || loaderApi.options.context;
         var resolve = options.resolve;
         var resolveMap = options.resolveMap;
         var resourcePath = options.path;
@@ -32,7 +33,7 @@ module.exports = function (options) {
                         // this path will be added as JS require in the template
                         includes.push(token.value);
                         // use the resolved path as token value, later on the template will be registered with this same id
-                        token.value = utils.generateTemplateId(resolveMap[normalizedTokenValue], loaderApi.options.context);
+                        token.value = utils.generateTemplateId(resolveMap[normalizedTokenValue], context);
                     }
                 }
             }

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -15,6 +15,7 @@ var resolveMap = {};
 module.exports = function (source) {
     var loaderApi = this;
     var loaderAsyncCallback = this.async();
+    var context = loaderApi.rootContext || loaderApi.options.context;
     this.cacheable && this.cacheable();
 
     // the path is saved to resolve other includes from
@@ -22,7 +23,7 @@ module.exports = function (source) {
 
     // this will be the template id for this resource,
     // this id is also be generated in the copiler when this resource is included
-    var id = utils.generateTemplateId(path, loaderApi.options.context);
+    var id = utils.generateTemplateId(path, context);
 
     var options = getOptions(loaderApi);
     var tpl;
@@ -77,7 +78,7 @@ module.exports = function (source) {
         // resolve all template async
         var resolveTemplates = function resolveTemplates() {
             async.each(resolveQueue, function (req, cb) {
-                loaderApi.resolve(loaderApi.context, req, function (err, res) {
+                loaderApi.resolve(context, req, function (err, res) {
                     if (err) {
                         // could not be resolved by webpack, mark as false so it can be
                         // ignored by the compiler


### PR DESCRIPTION
In Webpack v4.0.0 `this.context` was changed to `this.rootContext`
Reference: [https://webpack.js.org/api/loaders/#thisrootcontext](https://webpack.js.org/api/loaders/#thisrootcontext)

Using twig-loader in webpack >= 4.0.0 results in the following error:

```
Module build failed (from ./node_modules/twig-loader/index.js):
TypeError: Cannot read property 'context' of undefined
```

This update simply allows for either `this.context` or `this.rootContext` to be used by the compiler and loader.