### PR TITLE
Removing options property from loaderAPI

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -15,7 +15,7 @@ var resolveMap = {};
 module.exports = function (source) {
     var loaderApi = this;
     var loaderAsyncCallback = this.async();
-    var context = loaderApi.rootContext || loaderApi.options.context;
+    var context = loaderApi.rootContext || loaderApi.context;
     this.cacheable && this.cacheable();
 
     // the path is saved to resolve other includes from


### PR DESCRIPTION
In webpack 4, loaderAPI.options is null resulting in the following error...

```
TypeError: Cannot read property 'context' of undefined
    at Object.module.exports (/node_modules/twig-loader/lib/loader.js:25:63)
```
Although this wouldn't be supported on webpack < 4.