### PR TITLE
Added apply token

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -1,11 +1,10 @@
 var path = require("path");
 var _ = require("underscore");
 
-var utils = require('./utils');
+var utils = require("./utils");
 
 module.exports = function (options) {
     return function (id, tokens, pathToTwig) {
-
         var loaderApi = options.loaderApi;
         var context = loaderApi.rootContext || loaderApi.options.context;
         var resolve = options.resolve;
@@ -20,10 +19,13 @@ module.exports = function (options) {
                 // if we normalize this value, we:
                 // 1) can reuse this in the resolveMap for other components
                 // 2) we don't accidently reuse relative paths that would resolve differently
-                var normalizedTokenValue = path.resolve(path.dirname(resourcePath), token.value);
+                var normalizedTokenValue = path.resolve(
+                    path.dirname(resourcePath),
+                    token.value
+                );
 
                 // if not resolved before, add it to the list
-                if (typeof resolveMap[normalizedTokenValue] === 'undefined') {
+                if (typeof resolveMap[normalizedTokenValue] === "undefined") {
                     resolve(normalizedTokenValue);
                 } else {
                     // when false, the path could not be resolved, so we leave it
@@ -33,7 +35,10 @@ module.exports = function (options) {
                         // this path will be added as JS require in the template
                         includes.push(token.value);
                         // use the resolved path as token value, later on the template will be registered with this same id
-                        token.value = utils.generateTemplateId(resolveMap[normalizedTokenValue], context);
+                        token.value = utils.generateTemplateId(
+                            resolveMap[normalizedTokenValue],
+                            context
+                        );
                     }
                 }
             }
@@ -42,35 +47,40 @@ module.exports = function (options) {
         var processToken = function (token) {
             if (token.type === "logic" && token.token.type) {
                 switch (token.token.type) {
-                    case 'Twig.logic.type.block':
-                    case 'Twig.logic.type.if':
-                    case 'Twig.logic.type.elseif':
-                    case 'Twig.logic.type.else':
-                    case 'Twig.logic.type.for':
-                    case 'Twig.logic.type.spaceless':
-                    case 'Twig.logic.type.setcapture':
-                    case 'Twig.logic.type.macro':
+                    case "Twig.logic.type.block":
+                    case "Twig.logic.type.if":
+                    case "Twig.logic.type.elseif":
+                    case "Twig.logic.type.else":
+                    case "Twig.logic.type.for":
+                    case "Twig.logic.type.spaceless":
+                    case "Twig.logic.type.setcapture":
+                    case "Twig.logic.type.macro":
+                    case 'Twig.logic.type.apply':
                         _.each(token.token.output, processToken);
                         break;
-                    case 'Twig.logic.type.extends':
-                    case 'Twig.logic.type.include':
+                    case "Twig.logic.type.extends":
+                    case "Twig.logic.type.include":
                         // only process includes by webpack if they are strings
                         // otherwise just leave them for runtime to be handled
                         // since it's possible to pre-register templates that
                         // will be resolved during runtime
-                        if (token.token.stack.every(function (token) {
-                                return token.type === 'Twig.expression.type.string';
-                            })) {
+                        if (
+                            token.token.stack.every(function (token) {
+                                return (
+                                    token.type === "Twig.expression.type.string"
+                                );
+                            })
+                        ) {
                             _.each(token.token.stack, processDependency);
                         }
                         break;
-                    case 'Twig.logic.type.embed':
+                    case "Twig.logic.type.embed":
                         _.each(token.token.output, processToken);
                         _.each(token.token.stack, processDependency);
                         break;
-                    case 'Twig.logic.type.import':
-                    case 'Twig.logic.type.from':
-                        if (token.token.expression !== '_self') {
+                    case "Twig.logic.type.import":
+                    case "Twig.logic.type.from":
+                        if (token.token.expression !== "_self") {
                             _.each(token.token.stack, processDependency);
                         }
                         break;
@@ -90,10 +100,10 @@ module.exports = function (options) {
         });
         var output = [
             'var twig = require("' + pathToTwig + '").twig,',
-            '    tokens = ' + JSON.stringify(parsedTokens) + ',',
-            '    template = twig(' + JSON.stringify(opts) + ');\n',
-            'module.exports = function(context) { return template.render(context); }\n',
-            'module.exports.tokens = tokens;'
+            "    tokens = " + JSON.stringify(parsedTokens) + ",",
+            "    template = twig(" + JSON.stringify(opts) + ");\n",
+            "module.exports = function(context) { return template.render(context); }\n",
+            "module.exports.tokens = tokens;",
         ];
         // we export the tokens on the function as well, so they can be used to re-register this template
         // under a different id. This is useful for dynamic template support when loading the templates
@@ -105,6 +115,6 @@ module.exports = function (options) {
             });
         }
 
-        return output.join('\n');
+        return output.join("\n");
     };
 };


### PR DESCRIPTION
Dependencies (`includes` in my case) did not get resolved when they have been wrapped in a combination of the apply tag with the spaceless filter.

```twig
{% apply spaceless %}
    <div>
        {% include '/path/file.twig' %}
    </div>
{% endapply %}
```