### PR TITLE
Replace deprecated spaceless usage

### DIFF
--- a/test/fixtures/include/template.html.twig
+++ b/test/fixtures/include/template.html.twig
@@ -16,6 +16,6 @@
   {% include './f.html.twig' %}
 {% endblock %}
 
-{% spaceless %}
+{% apply spaceless %}
   {% include './g.html.twig' %}
-{% endspaceless %}
+{% endapply %}


### PR DESCRIPTION
The `spaceless` tag is deprecated since twig 1.38 https://twig.symfony.com/doc/1.x/tags/spaceless.html

The replacement is straightforward https://twig.symfony.com/doc/2.x/filters/spaceless.html