### PR TITLE
Pass thru twigOptions to compiler regardless of code path

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -48,13 +48,15 @@ module.exports = function (source) {
 
         Twig.extend(function (Twig) {
             var compiler = Twig.compiler;
-            // pass values to the compiler, and return the compiler function
-            compiler.module['webpack'] = compilerFactory({
+            var compilerOptions = {
                 loaderApi: loaderApi,
                 resolve: resolve,
                 resolveMap: resolveMap,
                 path: path
-            });
+            };
+            Object.assign(compilerOptions, options);
+            // pass values to the compiler, and return the compiler function
+            compiler.module['webpack'] = compilerFactory(compilerOptions);
         });
 
         tpl = Twig.twig({


### PR DESCRIPTION
Hi 🙂

Thank you for maintaining this library! 

When investigating the cause of some twig templates not behaving the way I'd expect, I found that options I had set in my webpack.config.js weren't actually applying when the twig-loader was creating js output.

Specifically, I was expecting:
```javascript
rules: [
            {
                test: /\.twig$/,
                loader: "twig-loader",
                options: {
                    twigOptions {
                        autoescape: true
                    }
                },
            }
        ]
```

to pass through the `autoescape: true` option to twigjs, such that the resulting js output would resemble the following
```javascript
var twig = ...,
      tokens = [...],
      template = twig({"autoescape":true,...});
      ...
```

but instead the autoescape option was completely missing from the generated template.

This PR should remedy it, but I'd be more than happy to know if I'm missing something / if there's a better approach.